### PR TITLE
Address missing logging and providers in bluetoothStack.wprp

### DIFF
--- a/bluetooth/tracing/BluetoothStack.wprp
+++ b/bluetooth/tracing/BluetoothStack.wprp
@@ -806,12 +806,6 @@
       </Keywords>
     </EventProvider>
 
-    <EventProvider Id="Microsoft-Windows-AppModel-Exec" Name="EB65A492-86C0-406A-BACE-9912D595BD69" Level="5" NonPagedMemory="false">
-      <Keywords>
-        <Keyword Value="0xfffd"/>
-      </Keywords>
-    </EventProvider>
-
     <Profile Id="BluetoothStack.Light.Memory" LoggingMode="Memory" Name="BluetoothStack" DetailLevel="Light" Description="Bluetooth stack default profile">
       <Collectors>
         <EventCollectorId Value="Traces_paged">
@@ -920,7 +914,6 @@
             <EventProviderId Value="Microsoft.Windows.HostActivityManager"/>
             <EventProviderId Value="Microsoft.Windows.BackgroundManager"/>
             <EventProviderId Value="Microsoft.Windows.ActivationManager"/>
-            <EventProviderId Value="Microsoft-Windows-AppModel-Exec"/>
           </EventProviders>
         </EventCollectorId>
 
@@ -1076,7 +1069,6 @@
             <EventProviderId Value="Microsoft.Windows.HostActivityManager"/>
             <EventProviderId Value="Microsoft.Windows.BackgroundManager"/>
             <EventProviderId Value="Microsoft.Windows.ActivationManager"/>
-            <EventProviderId Value="Microsoft-Windows-AppModel-Exec"/>
           </EventProviders>
         </EventCollectorId>
 

--- a/bluetooth/tracing/BluetoothStack.wprp
+++ b/bluetooth/tracing/BluetoothStack.wprp
@@ -688,83 +688,125 @@
     <!-- Handsfree ETW providers. Kept separate for readability -->
     <EventProvider Id="Microsoft.Windows.Apps.CommsEnhancementRTProviders" Name="7665d4fd-30eb-4ddc-9dc1-4ebab74ed98e" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Shell.Components.Calling" Name="a5e3b77c-1a36-4f74-918e-9c928f7f0595" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-CallingShellPresenters" Name="a5347b8a-3c9c-4f07-9440-1e0c5cfcc9d0" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-PhoneOm" Name="e08c85f4-c224-499d-b5b3-c1bce960f096" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-PhoneProviders" Name="1db8dad0-7ca6-4f18-b357-43bfdd8c9806" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-PhoneUtil" Name="04a490d4-84c6-4920-9c22-51c80825ff2c" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-PhoneService" Name="cbbbc22d-2efe-4eae-9af5-f9c6cf113670" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft-Windows-Telephony-TelephonyInteractiveUser" Name="088a803b-578d-41b1-9402-92b7ceb380c8" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.CallsRTProviders" Name="b8020478-a6a8-42bb-9ede-b2d3ebf8da7c" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.PhoneProviders" Name="d7afa934-92e9-4f14-98f2-62f2486c39fb" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.PhoneService" Name="6892b716-cfea-4c82-9557-9c782e3f8c6c" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.PhoneShellUi" Name="4be7b04b-179f-47cb-b6d9-b58ceef35be7" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.PhoneUtilsProviders" Name="cf82aecb-ffff-4049-bd5b-687734a5d519" Level="5" NonPagedMemory="false">
       <Keywords>
-        <Keyword Value="0xfffd"/>
+        <Keyword Value="0xffffffffffffffff"/>
       </Keywords>
     </EventProvider>
 
     <EventProvider Id="Microsoft.Windows.Apps.TelephonyInteractiveUser" Name="1ac684f9-187b-400f-9cec-3ec143cc6610" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xffffffffffffffff"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft.Windows.Apps.VoipRTProviders" Name="6F63AEFB-2229-5444-C3B1-519681AB0654" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xffffffffffffffff"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft-Windows-Telephony-VoipRT" Name="bd1a62ed-263b-4a66-a574-1f43c79c64be" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xffffffffffffffff"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft.Windows.BrokerInfrastructure" Name="63b6c2d2-0440-44de-a674-aa51a251b123" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xfffd"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft.Windows.HostActivityManager" Name="f6a774e5-2fc7-5151-6220-e514f1f387b6" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xfffd"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft.Windows.BackgroundManager" Name="1941f2b9-0939-5d15-d529-cd333c8fed83" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xfffd"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft.Windows.ActivationManager" Name="cf7f94b3-08dc-5257-422f-497d7dc86ab3" Level="5" NonPagedMemory="false">
+      <Keywords>
+        <Keyword Value="0xfffd"/>
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="Microsoft-Windows-AppModel-Exec" Name="EB65A492-86C0-406A-BACE-9912D595BD69" Level="5" NonPagedMemory="false">
       <Keywords>
         <Keyword Value="0xfffd"/>
       </Keywords>
@@ -870,8 +912,15 @@
             <EventProviderId Value="Microsoft.Windows.Apps.PhoneShellUi"/>
             <EventProviderId Value="Microsoft.Windows.Apps.PhoneUtilsProviders"/>
             <EventProviderId Value="Microsoft.Windows.Apps.TelephonyInteractiveUser"/>
+            <EventProviderId Value="Microsoft.Windows.Apps.VoipRTProviders"/>
+            <EventProviderId Value="Microsoft-Windows-Telephony-VoipRT"/>
             <EventProviderId Value="Microsoft.Windows.TestExecution.WexLogger"/>
             <EventProviderId Value="Microsoft.Windows.Bluetooth.LooselyCoupledDevices"/>
+            <EventProviderId Value="Microsoft.Windows.BrokerInfrastructure"/>
+            <EventProviderId Value="Microsoft.Windows.HostActivityManager"/>
+            <EventProviderId Value="Microsoft.Windows.BackgroundManager"/>
+            <EventProviderId Value="Microsoft.Windows.ActivationManager"/>
+            <EventProviderId Value="Microsoft-Windows-AppModel-Exec"/>
           </EventProviders>
         </EventCollectorId>
 
@@ -1019,8 +1068,15 @@
             <EventProviderId Value="Microsoft.Windows.Apps.PhoneShellUi"/>
             <EventProviderId Value="Microsoft.Windows.Apps.PhoneUtilsProviders"/>
             <EventProviderId Value="Microsoft.Windows.Apps.TelephonyInteractiveUser"/>
+            <EventProviderId Value="Microsoft.Windows.Apps.VoipRTProviders"/>
+            <EventProviderId Value="Microsoft-Windows-Telephony-VoipRT"/>
             <EventProviderId Value="Microsoft.Windows.TestExecution.WexLogger"/>
             <EventProviderId Value="Microsoft.Windows.Bluetooth.LooselyCoupledDevices"/>
+            <EventProviderId Value="Microsoft.Windows.BrokerInfrastructure"/>
+            <EventProviderId Value="Microsoft.Windows.HostActivityManager"/>
+            <EventProviderId Value="Microsoft.Windows.BackgroundManager"/>
+            <EventProviderId Value="Microsoft.Windows.ActivationManager"/>
+            <EventProviderId Value="Microsoft-Windows-AppModel-Exec"/>
           </EventProviders>
         </EventCollectorId>
 


### PR DESCRIPTION
It was found out during 3rd party debug support where there were some missing logging info and providers, thus not able to provide effective support.

Fix is to correct the logging keywords of those existing providers, and also add other relevant providers.